### PR TITLE
Improvements to Linux installer

### DIFF
--- a/linux/apt.sh
+++ b/linux/apt.sh
@@ -182,6 +182,7 @@ function bastion::dependencies() {
   print::bastion "Installing Bastion dependencies..."
 
   install::package "ffmpeg"
+  install::package "youtube-dl"
 
   sudo npm install --global yarn 1>/dev/null || \
     print::error "Unable to download and install Yarn."

--- a/linux/dnf.sh
+++ b/linux/dnf.sh
@@ -181,8 +181,7 @@ function bastion::dependencies() {
     print::error "Unable to download and install Yarn."
 
   if ! hash ffmpeg &>/dev/null; then
-    sudo dnf -y -q install ffmpeg || sudo yarn global add ffbinaries
-    sudo ffbinaries --output=/usr/local/bin
+    sudo dnf -y -q install ffmpeg || (sudo yarn global add ffbinaries && sudo ffbinaries --output=/usr/local/bin)
   fi
 
   install::package "youtube-dl"

--- a/linux/dnf.sh
+++ b/linux/dnf.sh
@@ -185,6 +185,8 @@ function bastion::dependencies() {
     sudo ffbinaries --output=/usr/local/bin
   fi
 
+  install::package "youtube-dl"
+
   cd "$BASTION_DIR"
   yarn install --production --no-lockfile 1>/dev/null || \
     print::error "Unable to download and install node modules."

--- a/linux/pacman.sh
+++ b/linux/pacman.sh
@@ -5,7 +5,7 @@
 # <https://www.gnu.org/licenses/gpl.txt>.
 #
 # This is just a little script that can be downloaded from the internet to
-# install Bastion on a linux based operating system with the dnf package
+# install Bastion on a linux based operating system with the packman package
 # manager. It installs Bastion and all the required dependencies and packages.
 
 # Exit immediately if a pipeline, which may consist of a single simple command,
@@ -155,10 +155,7 @@ function bastion::dependencies() {
   sudo npm install --global yarn 1>/dev/null || \
     print::error "Unable to download and install Yarn."
 
-  if ! hash ffmpeg &>/dev/null; then
-    sudo dnf -y -q install ffmpeg || sudo yarn global add ffbinaries
-    sudo ffbinaries --output=/usr/local/bin
-  fi
+  install::package "ffmpeg"
 
   cd "$BASTION_DIR"
   yarn install --production --no-lockfile 1>/dev/null || \

--- a/linux/pacman.sh
+++ b/linux/pacman.sh
@@ -156,6 +156,7 @@ function bastion::dependencies() {
     print::error "Unable to download and install Yarn."
 
   install::package "ffmpeg"
+  install::package "youtube-dl"
 
   cd "$BASTION_DIR"
   yarn install --production --no-lockfile 1>/dev/null || \

--- a/linux/yum.sh
+++ b/linux/yum.sh
@@ -179,6 +179,7 @@ function bastion::dependencies() {
     print::error "Unable to download and install Yarn."
 
   install::package "ffmpeg"
+  install::package "youtube-dl"
 
   cd "$BASTION_DIR"
   yarn install --production --no-lockfile 1>/dev/null || \

--- a/linux/yum.sh
+++ b/linux/yum.sh
@@ -178,10 +178,7 @@ function bastion::dependencies() {
   sudo npm install --global yarn 1>/dev/null || \
     print::error "Unable to download and install Yarn."
 
-  if ! hash ffmpeg &>/dev/null; then
-    sudo dnf -y -q install ffmpeg || sudo yarn global add ffbinaries
-    sudo ffbinaries --output=/usr/local/bin
-  fi
+  install::package "ffmpeg"
 
   cd "$BASTION_DIR"
   yarn install --production --no-lockfile 1>/dev/null || \


### PR DESCRIPTION
* fix don't execute `ffbinaries`, unnecessarily, when it wasn't used to install `ffmpeg`
* fix: remove traces of `dnf` script from `pacman` and `yum` scripts to install `ffmpeg`
* feat: include global `youtube-dl` dependency